### PR TITLE
latex comment filter

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -105,7 +105,7 @@ function filter(text) {
       {pattern: /(\\title{)(.*?)(})/g, newValue: '$2'},
       {pattern: /(\\usepackage\[(.*?)]{)(.*?)(})/g, newValue: ''},
       {pattern: /(\\usepackage{)(.*?)(})/g, newValue: ''},
-      {pattern: /%[^\n]*/g, newValue: ''},
+      {pattern: /(?<!\\)%.*/g, newValue: ''},
     ]);
 
   for (let i = 0; i < regexes.length; i++) {

--- a/src/functions.js
+++ b/src/functions.js
@@ -105,6 +105,7 @@ function filter(text) {
       {pattern: /(\\title{)(.*?)(})/g, newValue: '$2'},
       {pattern: /(\\usepackage\[(.*?)]{)(.*?)(})/g, newValue: ''},
       {pattern: /(\\usepackage{)(.*?)(})/g, newValue: ''},
+      {pattern: /%[^\n]*/g, newValue: ''},
     ]);
 
   for (let i = 0; i < regexes.length; i++) {


### PR DESCRIPTION
This filter excludes comments (starting with `%`).

This matches:
- line entirely commented out: `% this is a comment`
- line with ending part commented: `this is text and %this is a comment`

And does not match:
- escaped `%` sign: `this is 30\%, and is not a comment`

How it works:
The regex `/(?<!\\)%.*/g` has:
- negative lookbehind: the character before must be different from `\`
- the percentage sign
- followed by any characters (until newline, where comment ends)

This filter has been tested by using the user filters in the extension. Please let me know if it has some issues